### PR TITLE
Add ZemiSmart RGBW light example

### DIFF
--- a/examples/ZemiSmart/.gitignore
+++ b/examples/ZemiSmart/.gitignore
@@ -1,0 +1,2 @@
+build/
+firmware/

--- a/examples/ZemiSmart/Makefile
+++ b/examples/ZemiSmart/Makefile
@@ -1,0 +1,19 @@
+PROGRAM = light
+
+EXTRA_COMPONENTS = \
+	extras/http-parser \
+	$(abspath ../../components/wolfssl) \
+	$(abspath ../../components/cJSON) \
+	$(abspath ../../components/homekit)
+
+FLASH_SIZE ?= 8
+HOMEKIT_SPI_FLASH_BASE_ADDR ?= 0x7A000
+
+EXTRA_CFLAGS += -I../.. -DHOMEKIT_SHORT_APPLE_UUIDS
+
+include $(SDK_PATH)/common.mk
+
+LIBS += m
+
+monitor:
+	$(FILTEROUTPUT) --port $(ESPPORT) --baud $(ESPBAUD) --elf $(PROGRAM_OUT)

--- a/examples/ZemiSmart/light.c
+++ b/examples/ZemiSmart/light.c
@@ -1,0 +1,241 @@
+/*  (c) 2018 HomeAccessoryKid
+ *  This example makes an RGBW smart lightbulb as offered on e.g. alibaba
+ *  with the brand of ZemiSmart. It uses an ESP8266 with a 1MB flash on a 
+ *  TYLE1R printed circuit board by TuyaSmart (also used in AiLight).
+ *  There are terminals with markings for GND, 3V3, Tx, Rx and IO0
+ *  There's a second GND terminal that can be used to set IO0 for flashing
+ *  Popping of the plastic cap is sometimes hard, but never destructive
+ *  Note that the LED color is COLD white.
+ *  Changing them for WARM is possible but requires skill and nerves.
+ */
+
+
+#include <stdio.h>
+#include <espressif/esp_wifi.h>
+#include <espressif/esp_sta.h>
+#include <esp/uart.h>
+#include <esp8266.h>
+#include <FreeRTOS.h>
+#include <task.h>
+
+#include <homekit/homekit.h>
+#include <homekit/characteristics.h>
+#include "wifi.h"
+
+#include <math.h>  //requires LIBS ?= hal m to be added to Makefile
+#include "mjpwm.h"
+
+
+static void wifi_init() {
+    struct sdk_station_config wifi_config = {
+        .ssid = WIFI_SSID,
+        .password = WIFI_PASSWORD,
+    };
+
+    sdk_wifi_set_opmode(STATION_MODE);
+    sdk_wifi_station_set_config(&wifi_config);
+    sdk_wifi_station_connect();
+}
+
+//http://blog.saikoled.com/post/44677718712/how-to-convert-from-hsi-to-rgb-white
+void hsi2rgbw(float h, float s, float i, int* rgbw) {
+    int r, g, b, w;
+    float cos_h, cos_1047_h;
+    //h = fmod(h,360); // cycle h around to 0-360 degrees
+    h = 3.14159*h/(float)180; // Convert to radians.
+    s /=(float)100; i/=(float)100; //from percentage to ratio
+    s = s>0?(s<1?s:1):0; // clamp s and i to interval [0,1]
+    i = i>0?(i<1?i:1):0;
+    i = i*sqrt(i); //shape intensity to have finer granularity near 0
+
+    if(h < 2.09439) {
+        cos_h = cos(h);
+        cos_1047_h = cos(1.047196667-h);
+        r = s*4095*i/3*(1+cos_h/cos_1047_h);
+        g = s*4095*i/3*(1+(1-cos_h/cos_1047_h));
+        b = 0;
+        w = 4095*(1-s)*i;
+    } else if(h < 4.188787) {
+        h = h - 2.09439;
+        cos_h = cos(h);
+        cos_1047_h = cos(1.047196667-h);
+        g = s*4095*i/3*(1+cos_h/cos_1047_h);
+        b = s*4095*i/3*(1+(1-cos_h/cos_1047_h));
+        r = 0;
+        w = 4095*(1-s)*i;
+    } else {
+        h = h - 4.188787;
+        cos_h = cos(h);
+        cos_1047_h = cos(1.047196667-h);
+        b = s*4095*i/3*(1+cos_h/cos_1047_h);
+        r = s*4095*i/3*(1+(1-cos_h/cos_1047_h));
+        g = 0;
+        w = 4095*(1-s)*i;
+    }
+
+    rgbw[0]=r;
+    rgbw[1]=g;
+    rgbw[2]=b;
+    rgbw[3]=w;
+}
+
+#define PIN_DI 				13
+#define PIN_DCKI 			15
+
+float hue,sat,bri;
+bool on;
+
+void lightSET(void) {
+    int rgbw[4];
+    if (on) {
+        printf("h=%d,s=%d,b=%d => ",(int)hue,(int)sat,(int)bri);
+        
+        hsi2rgbw(hue,sat,bri,rgbw);
+        printf("r=%d,g=%d,b=%d,w=%d\n",rgbw[0],rgbw[1],rgbw[2],rgbw[3]);
+        
+        mjpwm_send_duty(rgbw[0],rgbw[1],rgbw[2],rgbw[3]);
+    } else {
+        printf("off\n");
+        mjpwm_send_duty(     0,      0,      0,      0 );
+    }
+}
+
+void light_init() {
+    mjpwm_cmd_t init_cmd = {
+        .scatter = MJPWM_CMD_SCATTER_APDM,
+        .frequency = MJPWM_CMD_FREQUENCY_DIVIDE_1,
+        .bit_width = MJPWM_CMD_BIT_WIDTH_12,
+        .reaction = MJPWM_CMD_REACTION_FAST,
+        .one_shot = MJPWM_CMD_ONE_SHOT_DISABLE,
+        .resv = 0,
+    };
+    mjpwm_init(PIN_DI, PIN_DCKI, 1, init_cmd);
+    on=true; hue=0; sat=0; bri=100; //this should not be here, but part of the homekit init work
+    lightSET();
+}
+
+homekit_value_t light_on_get() {
+    return HOMEKIT_BOOL(on);
+}
+void light_on_set(homekit_value_t value) {
+    if (value.format != homekit_format_bool) {
+        printf("Invalid on-value format: %d\n", value.format);
+        return;
+    }
+    on = value.bool_value;
+    lightSET();
+}
+
+homekit_value_t light_bri_get() {
+    return HOMEKIT_INT(bri);
+}
+void light_bri_set(homekit_value_t value) {
+    if (value.format != homekit_format_int) {
+        printf("Invalid bri-value format: %d\n", value.format);
+        return;
+    }
+    bri = value.int_value;
+    lightSET();
+}
+
+homekit_value_t light_hue_get() {
+    return HOMEKIT_FLOAT(hue);
+}
+void light_hue_set(homekit_value_t value) {
+    if (value.format != homekit_format_float) {
+        printf("Invalid hue-value format: %d\n", value.format);
+        return;
+    }
+    hue = value.float_value;
+    lightSET();
+}
+
+homekit_value_t light_sat_get() {
+    return HOMEKIT_FLOAT(sat);
+}
+void light_sat_set(homekit_value_t value) {
+    if (value.format != homekit_format_float) {
+        printf("Invalid sat-value format: %d\n", value.format);
+        return;
+    }
+    sat = value.float_value;
+    lightSET();
+}
+
+
+void light_identify_task(void *_args) {
+    for (int i=0;i<5;i++) {
+        mjpwm_send_duty(4095,    0,    0,    0);
+        vTaskDelay(300 / portTICK_PERIOD_MS); //0.3 sec
+        mjpwm_send_duty(   0, 4095,    0,    0);
+        vTaskDelay(300 / portTICK_PERIOD_MS); //0.3 sec
+        mjpwm_send_duty(   0,    0, 4095,    0);
+        vTaskDelay(300 / portTICK_PERIOD_MS); //0.3 sec
+    }
+    lightSET();
+
+    vTaskDelete(NULL);
+}
+
+void light_identify(homekit_value_t _value) {
+    printf("Light Identify\n");
+    xTaskCreate(light_identify_task, "Light identify", 256, NULL, 2, NULL);
+}
+
+
+homekit_accessory_t *accessories[] = {
+    HOMEKIT_ACCESSORY(
+        .id=1,
+        .category=homekit_accessory_category_lightbulb,
+        .services=(homekit_service_t*[]){
+            HOMEKIT_SERVICE(ACCESSORY_INFORMATION,
+                .characteristics=(homekit_characteristic_t*[]){
+                    HOMEKIT_CHARACTERISTIC(NAME, "Light"),
+                    HOMEKIT_CHARACTERISTIC(MANUFACTURER, "HacK"),
+                    HOMEKIT_CHARACTERISTIC(SERIAL_NUMBER, "1"),
+                    HOMEKIT_CHARACTERISTIC(MODEL, "ZemiSmart"),
+                    //HOMEKIT_CHARACTERISTIC(FIRMWARE_REVISION, "0.1"),
+                    HOMEKIT_CHARACTERISTIC(IDENTIFY, light_identify),
+                    NULL
+                }),
+            HOMEKIT_SERVICE(LIGHTBULB, .primary=true,
+                .characteristics=(homekit_characteristic_t*[]){
+                    HOMEKIT_CHARACTERISTIC(
+                        ON, true,
+                        .getter=light_on_get,
+                        .setter=light_on_set
+                    ),
+                    HOMEKIT_CHARACTERISTIC(
+                        BRIGHTNESS, 100,
+                        .getter=light_bri_get,
+                        .setter=light_bri_set
+                    ),
+                    HOMEKIT_CHARACTERISTIC(
+                        HUE, 0,
+                        .getter=light_hue_get,
+                        .setter=light_hue_set
+                    ),
+                    HOMEKIT_CHARACTERISTIC(
+                        SATURATION, 0,
+                        .getter=light_sat_get,
+                        .setter=light_sat_set
+                    ),
+                    NULL
+                }),
+            NULL
+        }),
+    NULL
+};
+
+homekit_server_config_t config = {
+    .accessories = accessories,
+    .password = "111-11-111"
+};
+
+void user_init(void) {
+    uart_set_baud(0, 115200);
+
+    wifi_init();
+    light_init();
+    homekit_server_init(&config);
+}

--- a/examples/ZemiSmart/mjpwm.c
+++ b/examples/ZemiSmart/mjpwm.c
@@ -1,0 +1,233 @@
+/******************************************************************************
+ * Copyright 2015 Vowstar Co.,Ltd.
+ *
+ * FileName: mjpwm.c
+ *
+ * Description: MJPWM Driver
+ *
+ * Modification history:
+ *     2015/09/10, v1.0 create this file.
+ *     ??????????, found in noduino sources
+ *     2017/12/24, adapted for esp-open-rtos
+*******************************************************************************/
+#include "mjpwm.h"
+#include <espressif/esp_misc.h>  //defines sdk_os_delay_us
+#include <task.h>
+#include <esp/gpio.h>
+
+#define GPIO_MAX_INDEX 16
+
+#ifndef LOW
+#define LOW                             (0)
+#endif              /* ifndef LOW */
+
+#ifndef HIGH
+#define HIGH                            (1)
+#endif              /* ifndef HIGH */
+
+//#define MJPWM_DIRECT_GPIO(pin)        PIN_FUNC_SELECT(pin_name[pin], pin_func[pin])
+#define MJPWM_DIRECT_GPIO(pin)          gpio_enable(pin,GPIO_OUTPUT)
+////#define MJPWM_DIRECT_READ(pin)      (0x01 & GPIO_INPUT_GET(GPIO_ID_PIN(pin)))
+////#define MJPWM_DIRECT_MODE_INPUT(pin)    (GPIO_DIS_OUTPUT(GPIO_ID_PIN(pin)))
+#define MJPWM_DIRECT_MODE_OUTPUT(pin)
+//#define MJPWM_DIRECT_WRITE_LOW(pin)   (GPIO_OUTPUT_SET(GPIO_ID_PIN(pin), LOW))
+#define MJPWM_DIRECT_WRITE_LOW(pin)     gpio_write(pin,0)
+//#define MJPWM_DIRECT_WRITE_HIGH(pin)  (GPIO_OUTPUT_SET(GPIO_ID_PIN(pin), HIGH))
+#define MJPWM_DIRECT_WRITE_HIGH(pin)    gpio_write(pin,1)
+
+
+static int nc = 2;
+
+static uint8_t pin_di = 13;
+static uint8_t pin_dcki = 15;
+
+static mjpwm_cmd_t mjpwm_commands[GPIO_MAX_INDEX + 1];
+
+IRAM void mjpwm_di_pulse(uint16_t times)
+{
+    uint16_t i;
+    for (i = 0; i < times; i++) {
+        MJPWM_DIRECT_WRITE_HIGH(pin_di);
+        asm("nop;");    // delay 50ns
+        MJPWM_DIRECT_WRITE_LOW(pin_di);
+        asm("nop;nop;nop;nop;nop;");
+        // delay 230ns
+    }
+}
+
+void mjpwm_dcki_pulse(uint16_t times)
+{
+    uint16_t i;
+    for (i = 0; i < times; i++) {
+        MJPWM_DIRECT_WRITE_HIGH(pin_dcki);
+        asm("nop;");        // delay 50ns
+        MJPWM_DIRECT_WRITE_LOW(pin_dcki);
+        asm("nop;");        // delay 50ns
+    }
+}
+
+void mjpwm_send_command(mjpwm_cmd_t command)
+{
+    uint8_t i, n;
+    uint8_t command_data;
+    mjpwm_commands[pin_dcki] = command;
+
+    taskENTER_CRITICAL(); //ets_intr_lock();
+    // TStop > 12us.
+    sdk_os_delay_us(12);
+    // Send 12 DI pulse, after 6 pulse's falling edge store duty data, and 12
+    // pulse's rising edge convert to command mode.
+    mjpwm_di_pulse(12);
+    // Delay >12us, begin send CMD data
+    sdk_os_delay_us(12);
+    asm("nop;nop;");
+    // Send CMD data
+
+    for (n = 0; n < nc; n++) {
+
+        command_data = *(uint8_t *) (&command);
+
+        for (i = 0; i < 4; i++) {
+            // DCK = 0;
+            MJPWM_DIRECT_WRITE_LOW(pin_dcki);
+            if (command_data & 0x80) {
+                // DI = 1;
+                MJPWM_DIRECT_WRITE_HIGH(pin_di);
+            } else {
+                // DI = 0;
+                MJPWM_DIRECT_WRITE_LOW(pin_di);
+            }
+            // DCK = 1;
+            MJPWM_DIRECT_WRITE_HIGH(pin_dcki);
+            command_data = command_data << 1;
+            if (command_data & 0x80) {
+                // DI = 1;
+                MJPWM_DIRECT_WRITE_HIGH(pin_di);
+            } else {
+                // DI = 0;
+                MJPWM_DIRECT_WRITE_LOW(pin_di);
+            }
+            // DCK = 0;
+            MJPWM_DIRECT_WRITE_LOW(pin_dcki);
+            // DI = 0;
+            MJPWM_DIRECT_WRITE_LOW(pin_di);
+            command_data = command_data << 1;
+        }
+
+        asm("nop;nop;nop;");
+    }
+
+    // TStart > 12us. Delay 12 us.
+    sdk_os_delay_us(12);
+    // Send 16 DI pulse，at 14 pulse's falling edge store CMD data, and
+    // at 16 pulse's falling edge convert to duty mode.
+    mjpwm_di_pulse(16);
+    // TStop > 12us.
+    sdk_os_delay_us(12);
+    asm("nop;nop;");
+    taskEXIT_CRITICAL(); //ets_intr_unlock();
+}
+
+IRAM void mjpwm_send_duty(uint16_t duty_r, uint16_t duty_g,
+        uint16_t duty_b, uint16_t duty_w)
+{
+    uint8_t i = 0, n;
+    uint8_t channel = 0;
+    uint8_t bit_length = 8;
+    uint16_t duty_current = 0;
+
+    // Definition for RGBW channels
+    uint16_t duty[4] = { duty_r, duty_g, duty_b, duty_w };
+
+    switch (mjpwm_commands[pin_dcki].bit_width) {
+    case MJPWM_CMD_BIT_WIDTH_16:
+        bit_length = 16;
+        break;
+    case MJPWM_CMD_BIT_WIDTH_14:
+        bit_length = 14;
+        break;
+    case MJPWM_CMD_BIT_WIDTH_12:
+        bit_length = 12;
+        break;
+    case MJPWM_CMD_BIT_WIDTH_8:
+        bit_length = 8;
+        break;
+    default:
+        bit_length = 8;
+        break;
+    }
+
+    taskENTER_CRITICAL(); //ets_intr_lock();
+    // TStop > 12us.
+    sdk_os_delay_us(12);
+    asm("nop;nop;");
+
+    for (n = 0; n < nc; n++)
+    {
+        for (channel = 0; channel < 4; channel++)   //RGBW 4CH
+        {
+            // RGBW Channel
+            duty_current = duty[channel];
+            // Send 8bit/12bit/14bit/16bit Data
+            for (i = 0; i < bit_length / 2; i++) {
+
+                // DCK = 0;
+                MJPWM_DIRECT_WRITE_LOW(pin_dcki);
+                if (duty_current & (0x01 << (bit_length - 1))) {
+                    // DI = 1;
+                    MJPWM_DIRECT_WRITE_HIGH(pin_di);
+                } else {
+                    // DI = 0;
+                    MJPWM_DIRECT_WRITE_LOW(pin_di);
+                }
+
+                // DCK = 1;
+                MJPWM_DIRECT_WRITE_HIGH(pin_dcki);
+                duty_current = duty_current << 1;
+                if (duty_current & (0x01 << (bit_length - 1))) {
+                    // DI = 1;
+                    MJPWM_DIRECT_WRITE_HIGH(pin_di);
+                } else {
+                    // DI = 0;
+                    MJPWM_DIRECT_WRITE_LOW(pin_di);
+                }
+
+                //DCK = 0;
+                MJPWM_DIRECT_WRITE_LOW(pin_dcki);
+                //DI = 0;
+                MJPWM_DIRECT_WRITE_LOW(pin_di);
+
+                duty_current = duty_current << 1;
+            }
+        }
+    }
+
+    // TStart > 12us. Ready for send DI pulse.
+    sdk_os_delay_us(12);
+    // Send 8 DI pulse. After 8 pulse falling edge, store old data.
+    mjpwm_di_pulse(8);
+    // TStop > 12us.
+    sdk_os_delay_us(12);
+    asm("nop;nop;");
+    taskEXIT_CRITICAL(); //ets_intr_unlock();
+}
+
+void mjpwm_init(uint8_t di, uint8_t dcki, uint8_t n_chips, mjpwm_cmd_t cmd)
+{
+    pin_di = di;
+    pin_dcki = dcki;
+
+    MJPWM_DIRECT_GPIO(pin_di);
+    MJPWM_DIRECT_GPIO(pin_dcki);
+    MJPWM_DIRECT_MODE_OUTPUT(pin_di);
+    MJPWM_DIRECT_MODE_OUTPUT(pin_dcki);
+    MJPWM_DIRECT_WRITE_LOW(pin_di);
+    MJPWM_DIRECT_WRITE_LOW(pin_dcki);
+
+    nc = n_chips;
+
+    // Clear all duty register
+    mjpwm_dcki_pulse(32 * nc);
+
+    mjpwm_send_command(cmd);
+}

--- a/examples/ZemiSmart/mjpwm.h
+++ b/examples/ZemiSmart/mjpwm.h
@@ -1,0 +1,73 @@
+/******************************************************************************
+ * Copyright 2015 Vowstar Co.,Ltd.
+ *
+ * FileName: mjpwm.h
+ *
+ * Description: MJPWM Driver
+ *
+ * Modification history:
+ *     2015/09/10, v1.0 create this file.
+ *     ??????????, found in noduino sources
+ *     2017/12/24, adapted for esp-open-rtos
+*******************************************************************************/
+
+#ifndef __MJPWM_H__
+#define __MJPWM_H__
+
+#include <FreeRTOS.h>  //added for esp-open-rtos
+
+typedef enum mjpwm_cmd_one_shot_t {
+    MJPWM_CMD_ONE_SHOT_DISABLE = 0X00,
+    MJPWM_CMD_ONE_SHOT_ENFORCE = 0X01,
+} mjpwm_cmd_one_shot_t;
+
+typedef enum mjpwm_cmd_reaction_t {
+    MJPWM_CMD_REACTION_FAST = 0X00,
+    MJPWM_CMD_REACTION_SLOW = 0X01,
+}  mjpwm_cmd_reaction_t;
+
+typedef enum mjpwm_cmd_bit_width_t {
+    MJPWM_CMD_BIT_WIDTH_16 = 0X00,
+    MJPWM_CMD_BIT_WIDTH_14 = 0X01,
+    MJPWM_CMD_BIT_WIDTH_12 = 0X02,
+    MJPWM_CMD_BIT_WIDTH_8 = 0X03,
+} mjpwm_cmd_bit_width_t;
+
+typedef enum mjpwm_cmd_frequency_t {
+    MJPWM_CMD_FREQUENCY_DIVIDE_1 = 0X00,
+    MJPWM_CMD_FREQUENCY_DIVIDE_4 = 0X01,
+    MJPWM_CMD_FREQUENCY_DIVIDE_16 = 0X02,
+    MJPWM_CMD_FREQUENCY_DIVIDE_64 = 0X03,
+} mjpwm_cmd_frequency_t;
+
+typedef enum mjpwm_cmd_scatter_t {
+    MJPWM_CMD_SCATTER_APDM = 0X00,
+    MJPWM_CMD_SCATTER_PWM = 0X01,
+} mjpwm_cmd_scatter_t;
+
+typedef struct mjpwm_cmd_t {
+    mjpwm_cmd_scatter_t scatter: 1;
+    mjpwm_cmd_frequency_t frequency: 2;
+    mjpwm_cmd_bit_width_t bit_width: 2;
+    mjpwm_cmd_reaction_t reaction: 1;
+    mjpwm_cmd_one_shot_t one_shot: 1;
+    uint8_t resv: 1;
+} __attribute__((aligned(1), packed)) mjpwm_cmd_t;
+
+#define MJPWM_COMMAND_DEFAULT \
+{ \
+    .scatter = mjpwm_cmd_scatter_apdm, \
+    .frequency = mjpwm_cmd_frequency_divide_1, \
+    .bit_width = mjpwm_cmd_bit_width_8, \
+    .reaction = mjpwm_cmd_reaction_fast, \
+    .one_shot = mjpwm_cmd_one_shot_disable, \
+    .resv = 0, \
+}
+
+void mjpwm_init(uint8_t pin_di, uint8_t pin_dcki, uint8_t n_chips, mjpwm_cmd_t command);
+void mjpwm_di_pulse(uint16_t times);
+void mjpwm_dcki_pulse(uint16_t times);
+void mjpwm_send_command(mjpwm_cmd_t command);
+void mjpwm_send_duty(uint16_t duty_r, uint16_t duty_g, uint16_t duty_b, uint16_t duty_w);
+
+#endif /* __MJPWM_H__ */


### PR DESCRIPTION
 *  This example makes an RGBW smart lightbulb as offered on e.g. alibaba
 *  with the brand of ZemiSmart. It uses an ESP8266 with a 1MB flash on a 
 *  TYLE1R printed circuit board by TuyaSmart (also used in AiLight).
 *  There are terminals with markings for GND, 3V3, Tx, Rx and IO0
 *  There's a second GND terminal that can be used to set IO0 for flashing
 *  Popping of the plastic cap is sometimes hard, but never destructive
 *  Note that the LED color is COLD white.
 *  Changing them for WARM is possible but requires skill and nerves.