### PR TITLE
Add Sonoff Basic example

### DIFF
--- a/examples/sonoff_basic/.gitignore
+++ b/examples/sonoff_basic/.gitignore
@@ -1,0 +1,2 @@
+build/
+firmware/

--- a/examples/sonoff_basic/Makefile
+++ b/examples/sonoff_basic/Makefile
@@ -1,0 +1,21 @@
+PROGRAM = sonoff_basic
+
+EXTRA_COMPONENTS = \
+	extras/http-parser \
+	extras/dhcpserver \
+	$(abspath ../../components/wifi_config) \
+	$(abspath ../../components/wolfssl) \
+	$(abspath ../../components/cJSON) \
+	$(abspath ../../components/homekit)
+
+FLASH_SIZE = 8
+FLASH_MODE = dout
+FLASH_SPEED = 40
+HOMEKIT_SPI_FLASH_BASE_ADDR = 0x7A000
+
+EXTRA_CFLAGS += -I../.. -DHOMEKIT_SHORT_APPLE_UUIDS
+
+include $(SDK_PATH)/common.mk
+
+monitor:
+	$(FILTEROUTPUT) --port $(ESPPORT) --baud 115200 --elf $(PROGRAM_OUT)

--- a/examples/sonoff_basic/main.c
+++ b/examples/sonoff_basic/main.c
@@ -70,14 +70,14 @@ void switch_on_callback(homekit_characteristic_t *_ch, homekit_value_t on, void 
 
 void button_intr_callback(uint8_t gpio) {
     if (gpio_read(button_gpio) == 1) {
-        //Toggle the sonoff
+        //Toggle the Sonoff when the built-in push button is pressed
         switch_on.value.bool_value = !switch_on.value.bool_value;
         relay_write(switch_on.value.bool_value);
         homekit_characteristic_notify(&switch_on, switch_on.value);
     }
 }
 
-void led_identify_task(void *_args) {
+void switch_identify_task(void *_args) {
     // We identify the Sonoff by Flashing it's LED.
     for (int i=0; i<3; i++) {
         for (int j=0; j<2; j++) {
@@ -95,20 +95,20 @@ void led_identify_task(void *_args) {
     vTaskDelete(NULL);
 }
 
-void led_identify(homekit_value_t _value) {
-    printf("LED identify\n");
-    xTaskCreate(led_identify_task, "LED identify", 128, NULL, 2, NULL);
+void switch_identify(homekit_value_t _value) {
+    printf("Switch identify\n");
+    xTaskCreate(switch_identify_task, "Switch identify", 128, NULL, 2, NULL);
 }
 
 homekit_accessory_t *accessories[] = {
     HOMEKIT_ACCESSORY(.id=1, .category=homekit_accessory_category_switch, .services=(homekit_service_t*[]){
         HOMEKIT_SERVICE(ACCESSORY_INFORMATION, .characteristics=(homekit_characteristic_t*[]){
-            HOMEKIT_CHARACTERISTIC(NAME, "Sonoff"),
+            HOMEKIT_CHARACTERISTIC(NAME, "Sonoff Switch"),
             HOMEKIT_CHARACTERISTIC(MANUFACTURER, "iTEAD"),
             HOMEKIT_CHARACTERISTIC(SERIAL_NUMBER, "037A2BABF19D"),
             HOMEKIT_CHARACTERISTIC(MODEL, "Basic"),
             HOMEKIT_CHARACTERISTIC(FIRMWARE_REVISION, "0.1"),
-            HOMEKIT_CHARACTERISTIC(IDENTIFY, led_identify),
+            HOMEKIT_CHARACTERISTIC(IDENTIFY, switch_identify),
             NULL
         }),
         HOMEKIT_SERVICE(SWITCH, .primary=true, .characteristics=(homekit_characteristic_t*[]){

--- a/examples/sonoff_basic/main.c
+++ b/examples/sonoff_basic/main.c
@@ -1,0 +1,138 @@
+/*
+ * Example of using esp-homekit library to control
+ * a simple $5 Sonoff Basic using HomeKit.
+ * The esp-wifi-config library is also used in this
+ * example. This means you don't have to specify
+ * your network's SSID and password before building.
+ *
+ * In order to flash the sonoff basic you will have to
+ * have a 3,3v (logic level) FTDI adapter.
+ *
+ * To flash this example connect 3,3v, TX, RX, GND
+ * in this order, beginning in the (square) pin header
+ * next to the button.
+ * Next hold down the button and connect the FTDI adapter
+ * to your computer. The sonoff is now in flash mode and
+ * you can flash the custom firmware.
+ *
+ * WARNING: Do not connect the sonoff to AC while it's
+ * connected to the FTDI adapter! This may fry your
+ * computer and sonoff.
+ *
+ */
+
+#include <stdio.h>
+#include <esp/uart.h>
+#include <esp8266.h>
+#include <FreeRTOS.h>
+#include <task.h>
+
+#include <homekit/homekit.h>
+#include <homekit/characteristics.h>
+#include <wifi_config.h>
+
+// The GPIO pin that is connected to the relay on the Sonoff Basic.
+const int relay_gpio = 12;
+// The GPIO pin that is connected to the LED on the Sonoff Basic.
+const int led_gpio = 13;
+// The GPIO pin that is oconnected to the button on the Sonoff Basic.
+const int button_gpio = 0;
+
+void relay_write(bool on) {
+    gpio_write(relay_gpio, on ? 1 : 0);
+}
+
+void led_write(bool on) {
+    gpio_write(led_gpio, on ? 0 : 1);
+}
+
+void switch_on_callback(homekit_characteristic_t *_ch, homekit_value_t on, void *context);
+
+void button_intr_callback(uint8_t gpio);
+
+homekit_characteristic_t switch_on = HOMEKIT_CHARACTERISTIC_(
+    ON, false, .callback=HOMEKIT_CHARACTERISTIC_CALLBACK(switch_on_callback)
+);
+
+void gpio_init() {
+    gpio_enable(led_gpio, GPIO_OUTPUT);
+    led_write(false);
+    gpio_enable(relay_gpio, GPIO_OUTPUT);
+    relay_write(switch_on.value.bool_value);
+    
+    gpio_set_pullup(button_gpio, true, true);
+    gpio_set_interrupt(button_gpio, GPIO_INTTYPE_EDGE_ANY, button_intr_callback);
+}
+
+void switch_on_callback(homekit_characteristic_t *_ch, homekit_value_t on, void *context) {
+    relay_write(switch_on.value.bool_value);
+}
+
+void button_intr_callback(uint8_t gpio) {
+    if (gpio_read(button_gpio) == 1) {
+        //Toggle the sonoff
+        switch_on.value.bool_value = !switch_on.value.bool_value;
+        relay_write(switch_on.value.bool_value);
+        homekit_characteristic_notify(&switch_on, switch_on.value);
+    }
+}
+
+void led_identify_task(void *_args) {
+    // We identify the Sonoff by Flashing it's LED.
+    for (int i=0; i<3; i++) {
+        for (int j=0; j<2; j++) {
+            led_write(true);
+            vTaskDelay(100 / portTICK_PERIOD_MS);
+            led_write(false);
+            vTaskDelay(100 / portTICK_PERIOD_MS);
+        }
+
+        vTaskDelay(250 / portTICK_PERIOD_MS);
+    }
+
+    led_write(false);
+
+    vTaskDelete(NULL);
+}
+
+void led_identify(homekit_value_t _value) {
+    printf("LED identify\n");
+    xTaskCreate(led_identify_task, "LED identify", 128, NULL, 2, NULL);
+}
+
+homekit_accessory_t *accessories[] = {
+    HOMEKIT_ACCESSORY(.id=1, .category=homekit_accessory_category_switch, .services=(homekit_service_t*[]){
+        HOMEKIT_SERVICE(ACCESSORY_INFORMATION, .characteristics=(homekit_characteristic_t*[]){
+            HOMEKIT_CHARACTERISTIC(NAME, "Sonoff"),
+            HOMEKIT_CHARACTERISTIC(MANUFACTURER, "iTEAD"),
+            HOMEKIT_CHARACTERISTIC(SERIAL_NUMBER, "037A2BABF19D"),
+            HOMEKIT_CHARACTERISTIC(MODEL, "Basic"),
+            HOMEKIT_CHARACTERISTIC(FIRMWARE_REVISION, "0.1"),
+            HOMEKIT_CHARACTERISTIC(IDENTIFY, led_identify),
+            NULL
+        }),
+        HOMEKIT_SERVICE(SWITCH, .primary=true, .characteristics=(homekit_characteristic_t*[]){
+            HOMEKIT_CHARACTERISTIC(NAME, "Sonoff Switch"),
+            &switch_on,
+            NULL
+        }),
+        NULL
+    }),
+    NULL
+};
+
+homekit_server_config_t config = {
+    .accessories = accessories,
+    .password = "111-11-111"
+};
+
+void on_wifi_ready() {
+    homekit_server_init(&config);
+}
+
+void user_init(void) {
+    uart_set_baud(0, 115200);
+
+    wifi_config_init("sonoff-switch", NULL, on_wifi_ready);
+    gpio_init();
+}


### PR DESCRIPTION
This PR adds an example for the Sonoff Basic by iTead. This example has been combined with the wifi_config example, so the Sonoff will broadcast an Access Point before it connects to your WiFi

![Sonoff Basic](https://user-images.githubusercontent.com/830094/34836969-b218b1ae-f6f9-11e7-9517-62d6799b8644.jpg)

In order to put this example onto the Sonoff you will have to open the Sonoff's case (voiding the warranty) and connect the following pins to a 3,3v (logic level) FTDI adapter:
- 3,3v on the FTDI adapter to 3,3v on the Sonoff, the square pin next to the button.
- TX on the FTDI to RX on the Sonoff, next to the 3,3v  on the Sonoff.
- RX on the FTDI to TX on the Sonoff, next to the TX  on the Sonoff.
- GND on the FTDI to GND on the Sonoff, next to the RX on the Sonoff.

![Sonoff Basic Header Pins](https://user-images.githubusercontent.com/830094/34837126-25a246b2-f6fa-11e7-8523-d70134de17bc.jpeg)

Next, you connect the FTDI adapter to your computer while holding down the button on the Sonoff. This will put it into flash mode. Do remember to also keep the pins connected, disconnecting one of the pins will make it leave flash mode. 

**⚠️ Warning:** Do not connect the Sonoff to any appliance or AC while having the case open or the FTDI connected. This might fry your computer or Sonoff