### PR TITLE
sonoff_basic: Fix for rapidly switching the relay when pressing button

### DIFF
--- a/examples/sonoff_basic/main.c
+++ b/examples/sonoff_basic/main.c
@@ -37,6 +37,8 @@ const int relay_gpio = 12;
 const int led_gpio = 13;
 // The GPIO pin that is oconnected to the button on the Sonoff Basic.
 const int button_gpio = 0;
+// The minimum amount that has to occur between each button press.
+const uint16_t button_event_debounce_time = 100 / portTICK_PERIOD_MS;
 // The last time the button was pressed, in ticks.
 uint32_t last_button_event_time;
 
@@ -72,8 +74,7 @@ void switch_on_callback(homekit_characteristic_t *_ch, homekit_value_t on, void 
 
 void button_intr_callback(uint8_t gpio) {
     uint32_t now = xTaskGetTickCountFromISR();
-    uint16_t debounce_time = 100;
-    if ((now - last_button_event_time)*portTICK_PERIOD_MS < debounce_time) {
+    if ((now - last_button_event_time) < button_event_debounce_time) {
         // debounce time, ignore events
         return;
     }


### PR DESCRIPTION
A fix that makes sure that the relay in the Sonoff can't be rapidly switched using the push button on the Sonoff