### PR TITLE
Allow hardcoding wifi in sonoff_basic

### DIFF
--- a/examples/sonoff_basic/Makefile
+++ b/examples/sonoff_basic/Makefile
@@ -1,12 +1,22 @@
 PROGRAM = sonoff_basic
 
+# Set to true to use the hardcoded wifi configuration in wifi.h
+HARDCODE_WIFI = true
+
 EXTRA_COMPONENTS = \
 	extras/http-parser \
-	extras/dhcpserver \
-	$(abspath ../../components/wifi_config) \
 	$(abspath ../../components/wolfssl) \
 	$(abspath ../../components/cJSON) \
 	$(abspath ../../components/homekit)
+
+ifeq "$(HARDCODE_WIFI)" "true"
+	EXTRA_CFLAGS += -DHARDCODE_WIFI
+else
+	EXTRA_COMPONENTS = \
+		extras/dhcpserver \
+		$(abspath ../../components/wifi_config)
+endif
+
 
 FLASH_SIZE = 8
 FLASH_MODE = dout

--- a/examples/sonoff_basic/Makefile
+++ b/examples/sonoff_basic/Makefile
@@ -1,7 +1,7 @@
 PROGRAM = sonoff_basic
 
 # Set to true to use the hardcoded wifi configuration in wifi.h
-HARDCODE_WIFI = true
+HARDCODE_WIFI = false
 
 EXTRA_COMPONENTS = \
 	extras/http-parser \


### PR DESCRIPTION
For simplicity when hacking on the firmware, it may make sense to just hardcode the wifi configuration. This also has the convenient side-effect of greatly reducing the memory footprint, dependencies, as well as power requirements for initial wifi setup.