### PR TITLE
WiFi AP

### DIFF
--- a/examples/led_strip/Makefile
+++ b/examples/led_strip/Makefile
@@ -4,6 +4,8 @@ EXTRA_COMPONENTS = \
 	extras/http-parser \
 	extras/i2s_dma \
 	extras/ws2812_i2s \
+	extras/dhcpserver \
+	$(abspath ../../components/wifi_config) \
 	$(abspath ../../components/wolfssl) \
 	$(abspath ../../components/cJSON) \
 	$(abspath ../../components/homekit)
@@ -20,4 +22,3 @@ LIBS += m
 
 monitor:
 	$(FILTEROUTPUT) --port $(ESPPORT) --baud 115200 --elf $(PROGRAM_OUT)
-


### PR DESCRIPTION
* When accessory starts, it creates it's own WiFi AP "LED-XXXXXX"
* (where XXXXXX is last 3 digits of accessory's mac address in HEX).
* You will be presented with available WiFi networks to connect to.
* Accessory shuts down AP after successful connection.